### PR TITLE
bumped version v0.1.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ttyui"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "A tiny set of helpers for terminal interactivity, including readline, word selector and date selector."

--- a/src/readline.rs
+++ b/src/readline.rs
@@ -67,7 +67,7 @@ impl std::fmt::Debug for Buffer {
         f.debug_struct("Buffer")
             .field("debug", &self.debug)
             .field("double_line_response", &self.double_line_response)
-            .field("self.terminate_on_up_down", &self.terminate_on_up_down)
+            .field("terminate_on_up_down", &self.terminate_on_up_down)
             .field("index", &self.index)
             .field("text", &self.text);
         Ok(())


### PR DESCRIPTION
This PR contains a little enhancement of `prefix` functionality for the readline buffer.
The new Buffer.set_prefix method enables users to set any strings into the prefix string, which is displayed before words input:

```rust
fn main() -> io::Result<()> {
    let mut buf = Buffer::new();
    buf.set_prefix("ok::bokujo> ".to_string());
    buf.read_line()?;
    println!("\n\n[output]\n\x1b[33m{}\x1b[0m", buf.to_string(),);
    Ok(())
}

```