### PR TITLE
[bugfix] fixed cursor moving distance for Buffer.home() and Buffer.end()

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ttyui"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "A tiny set of helpers for terminal interactivity, including readline, word selector and date selector."

--- a/src/readline.rs
+++ b/src/readline.rs
@@ -131,13 +131,11 @@ impl Buffer {
     }
     fn home(&mut self) -> io::Result<Key> {
         self.term.move_cursor_left(self.text.len())?;
-        self.term.move_cursor_right(self.prefix.len())?;
         self.index = 0;
         Ok(Key::Home)
     }
     fn end(&mut self) -> io::Result<Key> {
-        self.term
-            .move_cursor_right(self.prefix.len() + self.text.len() - self.index)?;
+        self.term.move_cursor_right(self.text.len() - self.index)?;
         self.index = self.text.len();
         Ok(Key::End)
     }


### PR DESCRIPTION
fix for the following issue

* #2 