### PR TITLE
[bugfix] fixed distanse calculation and backspace behavior

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ttyui"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "A tiny set of helpers for terminal interactivity, including readline, word selector and date selector."

--- a/src/readline.rs
+++ b/src/readline.rs
@@ -130,7 +130,7 @@ impl Buffer {
         Ok(Key::Enter)
     }
     fn home(&mut self) -> io::Result<Key> {
-        self.term.move_cursor_left(self.text.len())?;
+        self.term.move_cursor_left(self.index)?;
         self.index = 0;
         Ok(Key::Home)
     }
@@ -151,7 +151,9 @@ impl Buffer {
     fn backspace(&mut self) -> io::Result<Key> {
         if self.index > 0 {
             self.term.clear_line()?;
-            self.term.move_cursor_left(self.text.len())?;
+            self.term
+                .move_cursor_left(self.text.len() + self.prefix.len())?;
+            write!(&self.term, "{}", self.prefix)?;
             self.text.remove(self.index - 1);
             self.index -= 1;
             write!(&self.term, "{}", self.text)?;


### PR DESCRIPTION
* fixed Shell.backspace() to print prefix before line renewal
* fixed Shell.home() and end() for valid cursor positioning. Past distance value for cursor moving is not considered with prefix and current index. Now fixed (and tested manually, orz. see also #3 ).

This PR contains fixation for following issues:

* #2 
* #6 